### PR TITLE
feat!(input-scale): input probability vectors must be 0 to 1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: aggutils
 Title: Utilities for Aggregating Probabilistic Forecasts
-Version: 1.0.2
+Version: 1.1.0
 Authors@R: c(
     person(given = "Molly",
            family = "Hickman",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: aggutils
 Title: Utilities for Aggregating Probabilistic Forecasts
-Version: 1.1.0
+Version: 2.0.0
 Authors@R: c(
     person(given = "Molly",
            family = "Hickman",
@@ -22,7 +22,7 @@ Description: Provides several methods for aggregating probabilistic forecasts. Y
 License: MIT + file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.1
 Imports: 
     stats,
     docstring

--- a/R/agg.R
+++ b/R/agg.R
@@ -16,7 +16,7 @@ preprocess <- function(x, q = 0) {
   #'
   #' @note Assumes forecasts are in the range 0 to 1, inclusive.
 
-  if (any(x > 1)) {
+  if (any(x > 1) || any(x < 0)) {
     stop("Forecasts must be in the range 0 to 1")
   }
 

--- a/R/agg.R
+++ b/R/agg.R
@@ -10,11 +10,15 @@ preprocess <- function(x, q = 0) {
   #' @param x A vector of forecasts
   #' @param q The quantile to use for replacing 0s and 1s (between 0 and 1)
   #' @return A vector of forecasts with 0s are replaced by the qth quantile and
-  #' 100s are replaced by the (1 - q)th quantile.
+  #' 1s are replaced by the (1 - q)th quantile.
   #'
   #' @importFrom stats quantile
   #'
-  #' @note Assumes forecasts are in the range 0 to 100, inclusive.
+  #' @note Assumes forecasts are in the range 0 to 1, inclusive.
+
+  if (any(x > 1)) {
+    stop("Forecasts must be in the range 0 to 1")
+  }
 
   x <- sort(x)
   x <- x[!is.na(x) & !is.nan(x)]
@@ -23,10 +27,10 @@ preprocess <- function(x, q = 0) {
     if (all(x == 0)) {
       # Replace them with 10^-12
       return(rep(10^-12, length(x)))
-    } else if (all(x == 100)) {
-      return(rep(100 - 10^-12, length(x)))
+    } else if (all(x == 1)) {
+      return(rep(1 - 10^-14, length(x)))
     }
-    x[x == 100] <- as.numeric(quantile(x[x != 100], 1 - q, na.rm = TRUE))
+    x[x == 1] <- as.numeric(quantile(x[x != 1], 1 - q, na.rm = TRUE))
     x[x == 0] <- as.numeric(quantile(x[x != 0], q, na.rm = TRUE))
   }
 
@@ -38,7 +42,7 @@ trim <- function(x, p = 0.1) {
   #'
   #' @description Trim the top and bottom (p*100)% of forecasts
   #'
-  #' @param x Vector of forecasts in 0 to 100 range (%)
+  #' @param x Vector of forecasts in 0 to 1 range
   #' @param p The proportion of forecasts to trim from each end (between 0 and
   #' 1)
   #' @return (numeric) The trimmed mean of the vector
@@ -63,7 +67,7 @@ hd_trim <- function(x, p = 0.1) {
   #' @note As p gets bigger this acts like a mode in a similar way to
   #' the symmetrically-trimmed mean acting like a median.
   #'
-  #' @param x Vector of forecasts in 0 to 100 range (%)
+  #' @param x Vector of forecasts in 0 to 1 range
   #' @param p The proportion of forecasts to trim (between 0 and 1)
   #' @return (numeric) The highest-density trimmed mean of the vector
   #'
@@ -92,7 +96,7 @@ soften_mean <- function(x, p = 0.1) {
   #' @description If the mean is > .5, trim the top trim%; if < .5, the bottom
   #' trim%. Return the new mean (i.e. soften the mean).
   #'
-  #' @param x Vector of forecasts in 0 to 100 range (%)
+  #' @param x Vector of forecasts in 0 to 1 range
   #' @param p The proportion of forecasts to trim from each end (between 0
   #' and 1)
   #' @return (numeric) The softened mean of the vector
@@ -120,7 +124,7 @@ neymanAggCalc <- function(x) {
   #'
   #' where n is the number of forecasts.
   #'
-  #' @param x Vector of forecasts in 0 to 100 range (%)
+  #' @param x Vector of forecasts in 0 to 1 range
   #' @return (numeric) The extremized mean of the vector
   #' @references Neyman, E. and Roughgarden, T. (2021). Are you
   #' smarter than a random expert? The robust aggregation of substitutable
@@ -129,13 +133,12 @@ neymanAggCalc <- function(x) {
   #'
   #' @export
 
-  x <- preprocess(x, q = 0.05)  # replace 0% forecasts with 5th percentile forecast
-  x <- (x / 100)
+  x <- preprocess(x, q = 0.05) # replace 0% forecasts with 5th percentile forecast
   n <- length(x)
   d <- (n * (sqrt((3 * n^2) - (3 * n) + 1) - 2)) / (n^2 - n - 1)
-  logodds <- log(x / (1 - x))  # log odds from probabilities
-  logodds <- mean(logodds) * d  # arithmetic mean, THEN extremize by factor d
-  return(100 * exp(logodds) / (1 + exp(logodds)))  # back to probability
+  logodds <- log(x / (1 - x)) # log odds from probabilities
+  logodds <- mean(logodds) * d # arithmetic mean, THEN extremize by factor d
+  return(exp(logodds) / (1 + exp(logodds))) # back to probability
 }
 
 geoMeanCalc <- function(x, q = 0.05) {
@@ -144,7 +147,7 @@ geoMeanCalc <- function(x, q = 0.05) {
   #' Calculate the geometric mean of a vector of forecasts. We handle 0s by
   #' replacing them with the qth quantile of the non-zero forecasts.
   #'
-  #' @param x Vector of forecasts in 0 to 100 range (%)
+  #' @param x Vector of forecasts in 0 to 1 range
   #' @param q The quantile to use for replacing 0s (between 0 and 1)
   #' @return (numeric) The geometric mean of the vector
   #' @note agg(a) + agg(not a) does not sum to 1 for this aggregation method.
@@ -167,12 +170,11 @@ geoMeanOfOddsCalc <- function(x, q = 0.05, odds = FALSE) {
   #' @param q The quantile to use for replacing 0s (between 0 and 1)
   #' @param odds Whether x is already in odds form (TRUE) or probabilities
   #' @return (numeric) The geometric mean of the odds
-  #' @note agg(a) + agg(not a) does not sum to 1 for this aggregation method.
   #'
   #' @export
 
   if (!odds) {
-    x <- preprocess(x, q) / 100
+    x <- preprocess(x, q)
     odds <- x / (1 - x)
   } else {
     odds <- x
@@ -180,5 +182,5 @@ geoMeanOfOddsCalc <- function(x, q = 0.05, odds = FALSE) {
   geoMeanOfOdds <- exp(mean(log(odds)))
   # Convert back to probability
   geoMeanOfOdds <- geoMeanOfOdds / (geoMeanOfOdds + 1)
-  return(geoMeanOfOdds * 100)
+  return(geoMeanOfOdds)
 }

--- a/man/geoMeanCalc.Rd
+++ b/man/geoMeanCalc.Rd
@@ -7,7 +7,7 @@
 geoMeanCalc(x, q = 0.05)
 }
 \arguments{
-\item{x}{Vector of forecasts in 0 to 100 range (\%)}
+\item{x}{Vector of forecasts in 0 to 1 range}
 
 \item{q}{The quantile to use for replacing 0s (between 0 and 1)}
 }

--- a/man/geoMeanOfOddsCalc.Rd
+++ b/man/geoMeanOfOddsCalc.Rd
@@ -21,6 +21,3 @@ Convert probabilities to odds, and calculate the geometric mean of the
 odds. We handle 0s by replacing them with the qth quantile of the non-zero
 forecasts, before converting.
 }
-\note{
-agg(a) + agg(not a) does not sum to 1 for this aggregation method.
-}

--- a/man/hd_trim.Rd
+++ b/man/hd_trim.Rd
@@ -7,7 +7,7 @@
 hd_trim(x, p = 0.1)
 }
 \arguments{
-\item{x}{Vector of forecasts in 0 to 100 range (\%)}
+\item{x}{Vector of forecasts in 0 to 1 range}
 
 \item{p}{The proportion of forecasts to trim (between 0 and 1)}
 }

--- a/man/neymanAggCalc.Rd
+++ b/man/neymanAggCalc.Rd
@@ -7,7 +7,7 @@
 neymanAggCalc(x)
 }
 \arguments{
-\item{x}{Vector of forecasts in 0 to 100 range (\%)}
+\item{x}{Vector of forecasts in 0 to 1 range}
 }
 \value{
 (numeric) The extremized mean of the vector

--- a/man/preprocess.Rd
+++ b/man/preprocess.Rd
@@ -13,12 +13,12 @@ preprocess(x, q = 0)
 }
 \value{
 A vector of forecasts with 0s are replaced by the qth quantile and
-100s are replaced by the (1 - q)th quantile.
+1s are replaced by the (1 - q)th quantile.
 }
 \description{
 This does the preprocessing steps that all the agg methods
 have in common.
 }
 \note{
-Assumes forecasts are in the range 0 to 100, inclusive.
+Assumes forecasts are in the range 0 to 1, inclusive.
 }

--- a/man/soften_mean.Rd
+++ b/man/soften_mean.Rd
@@ -7,7 +7,7 @@
 soften_mean(x, p = 0.1)
 }
 \arguments{
-\item{x}{Vector of forecasts in 0 to 100 range (\%)}
+\item{x}{Vector of forecasts in 0 to 1 range}
 
 \item{p}{The proportion of forecasts to trim from each end (between 0
 and 1)}

--- a/man/trim.Rd
+++ b/man/trim.Rd
@@ -7,7 +7,7 @@
 trim(x, p = 0.1)
 }
 \arguments{
-\item{x}{Vector of forecasts in 0 to 100 range (\%)}
+\item{x}{Vector of forecasts in 0 to 1 range}
 
 \item{p}{The proportion of forecasts to trim from each end (between 0 and
 1)}

--- a/tests/testthat/test-agg.R
+++ b/tests/testthat/test-agg.R
@@ -5,33 +5,31 @@ forecasts <- c(rep(.1, 5), rep(.2, 5), rep(.4, 5), rep(.5, 2), .8, .9, 1.0)
 test_that("trimmed mean works", {
   # Untrimmed, the mean is .36. Trimmed, it's .31875.
   expect_equal(round(trim(forecasts), 2), .32)
-}
-)
+})
 
 test_that("trimmed mean works with p arg", {
   # Same vector but trimming top and bottom 25% (leaving middle 50%).
   expect_equal(trim(forecasts, .25), .3)
-}
-)
+})
 
 test_that("P(a) + P(not a) = 1 always", {
   not_forecasts <- 1 - forecasts
   expect_equal(trim(forecasts) + aggutils::trim(not_forecasts), 1)
-  expect_equal(neymanAggCalc(forecasts*100) + neymanAggCalc(not_forecasts*100), 100)
+  expect_equal(neymanAggCalc(forecasts) + neymanAggCalc(not_forecasts), 1)
   expect_equal(hd_trim(forecasts) + hd_trim(not_forecasts), 1)
   # GeoMean doesn't have this property
-}
-)
+})
 
 test_that("Highest isn't more than 10x lowest", {
   # Make a vector containing each of the aggregation methods on forecasts.
   # The highest value should be no more than 10x the lowest.
-  agg_vec <- c(trim(forecasts*100), hd_trim(forecasts*100),
-               neymanAggCalc(forecasts*100), geoMeanCalc(forecasts*100),
-               geoMeanOfOddsCalc(forecasts*100))
+  agg_vec <- c(
+    trim(forecasts), hd_trim(forecasts),
+    neymanAggCalc(forecasts), geoMeanCalc(forecasts),
+    geoMeanOfOddsCalc(forecasts)
+  )
   expect_equal(max(agg_vec) / min(agg_vec) < 10, TRUE)
-}
-)
+})
 
 test_that("It works when they're all 0", {
   # Trim surely works
@@ -42,13 +40,19 @@ test_that("It works when they're all 0", {
 })
 
 test_that("Geo mean of odds of (a, b, c) and of (1-a, 1-b, 1-c) sums to 1", {
-  vecGMOD <- geoMeanOfOddsCalc(c(70, 20, 10))
-  recipVecGMOD <- geoMeanOfOddsCalc(c(30, 80, 90))
-  expect_equal(vecGMOD + recipVecGMOD, 100)
+  vecGMOD <- geoMeanOfOddsCalc(c(.7, .2, .1))
+  recipVecGMOD <- geoMeanOfOddsCalc(c(.3, .8, .9))
+  expect_equal(vecGMOD + recipVecGMOD, 1)
 })
 
 test_that("Same but directly provide odds", {
-  vecGMOD <- geoMeanOfOddsCalc(c(3./1., 1./2., 5./2.), odds = TRUE)
-  recipVecGMOD <- geoMeanOfOddsCalc(c(1./3., 2./1., 2./5.), odds = TRUE)
-  expect_equal(vecGMOD + recipVecGMOD, 100)
+  vecGMOD <- geoMeanOfOddsCalc(c(3. / 1., 1. / 2., 5. / 2.), odds = TRUE)
+  recipVecGMOD <- geoMeanOfOddsCalc(c(1. / 3., 2. / 1., 2. / 5.), odds = TRUE)
+  expect_equal(vecGMOD + recipVecGMOD, 1)
+})
+
+test_that("Geom Mean (Probabilities) reciprocal test (sum to less than...)", {
+  vec <- geoMeanCalc(c(.7, .2, .1))
+  recipVec <- geoMeanCalc(c(.3, .8, .9))
+  expect_lt(vec + recipVec, 1)
 })


### PR DESCRIPTION
Previously, the library expected forecasts to be on the 0 to 100 (percent) scale.

BREAKING CHANGE: The library now requires all forecasts to be on the 0 (no chance) to 1 (guaranteed) scale